### PR TITLE
korjaus koodiin

### DIFF
--- a/data/osa-6/1-toistuvat-sivurakenteet-ja-tyylitiedostot.md
+++ b/data/osa-6/1-toistuvat-sivurakenteet-ja-tyylitiedostot.md
@@ -439,7 +439,7 @@ Parametrin arvon voi luonnollisesti antaa myös muuttujana. Alla olevassa esimer
         <title>Otsikko</title>
     </head>
     <body>
-        <div th:replace="fragments/layout :: header(text='${otsikko}')"></div>
+        <div th:replace="fragments/layout :: header(text=${otsikko})"></div>
 
         <main>
             <ul>


### PR DESCRIPTION
Thymeleaf kutsuu palvelimen muuttujia "-merkkien sisällä ilman toisia heittomerkkejä. Ylimääräisillä heittomerkeillä muuttuja text saa merkkijonoarvon "otsikko".
Esim. palvelimen muuttujien käyttämisestä Thymeleafissä: https://www.thymeleaf.org/doc/articles/layouts.html#using-expressions